### PR TITLE
Launch Library 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![license: MIT](https://img.shields.io/github/license/mdubourg001/ssgo?style=flat-square)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 
-A simple way to stay up to date with upcoming space launches, built with [React-Native](https://github.com/facebook/react-native), using the [Launch Library API](https://launchlibrary.net/) and the [Spaceflight News API](https://spaceflightnewsapi.net/).
+A simple way to stay up to date with upcoming space launches, built with [React-Native](https://github.com/facebook/react-native), using the [Launch Library 2](https://thespacedevs.com/) and the [Spaceflight News API](https://spaceflightnewsapi.net/).
 
 ## Preview
 

--- a/src/common/Countdown.tsx
+++ b/src/common/Countdown.tsx
@@ -37,13 +37,14 @@ const StatusText = styled.Text`
 let timer;
 
 const Countdown = ({
-  wsstamp,
+  net,
   status,
 }: {
-  wsstamp: number;
+  net: Date;
   status?: number;
 }) => {
   const [timeLeft, setTimeLeft] = useState(0);
+  const wsstamp = new Date(net).getTime() / 1000
 
   useEffect(() => {
     updateTimeLeft();

--- a/src/components/CalendarCard.tsx
+++ b/src/components/CalendarCard.tsx
@@ -43,12 +43,12 @@ const Desc = styled.Text`
 `;
 
 export default ({ data, isFirst = false }) => {
-  const launchTime = new Date(data.netstamp * 1000);
+  const launchTime = new Date(data.net);
   return (
     <Wrapper isFirst={isFirst}>
       <Row>
         <DateWrapper>
-          {data.netstamp === 0 ? (
+          {launchTime.getTime() / 1000 === 0 ? (
             <Day>TBD</Day>
           ) : (
             <>
@@ -59,10 +59,10 @@ export default ({ data, isFirst = false }) => {
         </DateWrapper>
         <ContentWrapper>
           <Desc bold>{data.name}</Desc>
-          <Desc numberOfLines={1}>{data.location.name}</Desc>
+          <Desc numberOfLines={1}>{data.pad.name}</Desc>
           <Label
             numberOfLines={2}
-            text={data.lsp.name.length < 50 ? data.lsp.name : data.lsp.abbrev}
+            text={data.launch_service_provider.name.length < 50 ? data.launch_service_provider.name : data.launch_service_provider.abbrev}
           />
         </ContentWrapper>
       </Row>

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -56,7 +56,7 @@ const Carousel: React.FC<Props> = ({ launches, onItemPress }) => {
     return (
       <ItemWrapper onPress={() => onItemPress(item)}>
         <ParallaxImage
-          source={{ uri: item.rocket.imageURL }}
+          source={{ uri: item.image || item.rocket.configuration.image_url }}
           containerStyle={styles.imageContainer}
           style={styles.image}
           parallaxFactor={0.2}

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -38,11 +38,11 @@ interface Props {
 const Preview = ({ data, onPress }): Props => (
   <ItemWrapper onPress={onPress}>
     <Thumbnail
-      source={{ uri: data.rocket.imageURL }}
+      source={{ uri: data.image || data.rocket.configuration.image_url }}
       imageStyle={{ opacity: 0.9 }}
     >
       <Title>{data.name}</Title>
-      <Time>{data.windowstart}</Time>
+      <Time>{new Date(data.net).toLocaleString()}</Time>
     </Thumbnail>
   </ItemWrapper>
 );

--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -29,7 +29,7 @@ const ResultCard = ({ data, showDetails }) => {
   return (
     <Wrapper onPress={() => showDetails(data)}>
       <Title>{name}</Title>
-      <Subtitle>{net}</Subtitle>
+      <Subtitle>{new Date(net).toLocaleString()}</Subtitle>
     </Wrapper>
   );
 };

--- a/src/components/__tests__/ResultCard.test.tsx
+++ b/src/components/__tests__/ResultCard.test.tsx
@@ -7,7 +7,7 @@ describe("ResultCard", () => {
     const props = {
       data: {
         name: "$_TEST_NAME_$",
-        net: "$_TEST_NET_DATE_$",
+        net: "2020-08-05T02:00:00Z",
       },
       showDetails: jest.fn(),
     };

--- a/src/components/__tests__/__snapshots__/ResultCard.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ResultCard.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`ResultCard renders correctly 1`] = `
       ]
     }
   >
-    $_TEST_NET_DATE_$
+    8/5/2020, 4:00:00 AM
   </Text>
 </View>
 `;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,7 @@ export enum STATES {
 export const HEADER_HEIGHT = 50;
 export const TABBAR_HEIGHT = 70;
 
-export const API_URL = "https://launchlibrary.net/1.4/";
+export const API_URL = "https://ll.thespacedevs.com/2.0.0/";
 
 export const NEWS_API_URL = "https://spaceflightnewsapi.net/api/v1/";
 

--- a/src/helpers/status.tsx
+++ b/src/helpers/status.tsx
@@ -1,10 +1,12 @@
 const STATUS_MESSAGES = [
-  "Unknown Status",
-  "Launch is GO",
-  "Launch is NO-GO",
-  "Launch was a success",
-  "Launch failed",
+  "Launch is Go",
+  "Launch is To-Be-Determined",
+  "Launch was Successful",
+  "Launch was a Failure",
+  "Launch is in a Hold",
+  "Launch is In-Flight",
+  "Launch was a partial Failure"
 ];
 
 export const getStatusMessage = (statusNumber: number) =>
-  STATUS_MESSAGES[statusNumber] || "Unknown Status";
+  STATUS_MESSAGES[statusNumber - 1] || "Unknown Status";

--- a/src/screens/Calendar.tsx
+++ b/src/screens/Calendar.tsx
@@ -66,7 +66,7 @@ const Calendar: React.FC<Props> = observer(({ navigation }) => {
   }
 
   let titleIndex = 0;
-  const sectionTitles = ["Scheduled", "To be defined"];
+  const sectionTitles = ["Scheduled", "To be Determined"];
 
   return (
     <Wrapper>
@@ -80,7 +80,7 @@ const Calendar: React.FC<Props> = observer(({ navigation }) => {
           keyExtractor={(item) => item.id.toString()}
           renderItem={({ item }) => {
             const showTitle =
-              titleIndex === 0 || (item.netstamp === 0 && titleIndex === 1);
+              titleIndex === 0 || (new Date(item.net).getTime() / 1000 === 0 && titleIndex === 1);
             if (showTitle) titleIndex++;
             return (
               <>

--- a/src/screens/Dashboard.tsx
+++ b/src/screens/Dashboard.tsx
@@ -61,7 +61,7 @@ const Dashboard = observer(() => {
               data={data}
               onPress={() => navigation.navigate("Details", { data })}
             />
-            <Countdown wsstamp={data.wsstamp} status={data.status} />
+            <Countdown net={data.net} status={data.status.id} />
           </>
         );
     }

--- a/src/screens/Details.tsx
+++ b/src/screens/Details.tsx
@@ -81,8 +81,11 @@ const Details: React.FC<Props> = ({ route, navigation }) => {
   const appStateStore = useContext(AppState);
 
   const { data } = route.params;
-  const videoLink = data.vidURLs.length > 0 && data.vidURLs[0];
-  const wikiLink = data.missions[0]?.wikiURL;
+  const videoLink = data.vidURLs && data.vidURLs.length > 0 && data.vidURLs[0].url;
+  const wikiLink = data.launch_service_provider.wiki_url;
+  const lspAbbrev = data.launch_service_provider.abbrev ? data.launch_service_provider.abbrev : ""
+  const missionType = data.mission ? data.mission.type : "Unknown"
+  const missionDescription = data.mission ? data.mission.description : "No Description Available"
 
   const actionItems = [
     [
@@ -106,15 +109,15 @@ const Details: React.FC<Props> = ({ route, navigation }) => {
         thumbIcon: "Pin",
         thumbColor: "#2dcd55",
         action: () => {
-          const { longitude, latitude } = data.location.pads[0];
+          const { latitude, longitude } = data.pad;
+          const lat = parseFloat(latitude)
+          const lon = parseFloat(longitude)
           firebase.analytics().logEvent("OPEN_MAPS", { value: data.name });
-          openMap({ longitude, latitude });
+          openMap({ latitude: lat, longitude: lon });
         },
-        disabled: !data.location.pads[0],
-        preview: !data.location.pads[0] && "Unavailable",
       },
       {
-        title: "Wikipedia",
+        title: `${lspAbbrev} Wikipedia`,
         icon: "ChevronRight",
         preview: !wikiLink && "Unavailable",
         thumbIcon: "Globe",
@@ -137,9 +140,9 @@ const Details: React.FC<Props> = ({ route, navigation }) => {
   return (
     <View style={{ overflow: "hidden" }}>
       <Image
-        source={{ uri: data.rocket.imageURL }}
+        source={{ uri: data.image || data.rocket.configuration.image_url }}
         style={{ transform: [{ scale: ImageScale }] }}
-      ></Image>
+      />
       <Animated.ScrollView
         contentContainerStyle={{ paddingTop: IMAGE_HEIGHT }}
         onScroll={Animated.event(
@@ -152,33 +155,31 @@ const Details: React.FC<Props> = ({ route, navigation }) => {
         <View style={{ backgroundColor: colors.background }}>
           <ContentWrapper>
             <Title>{data.name}</Title>
-            <Countdown wsstamp={data.wsstamp} status={data.status} />
+            <Countdown net={data.net} status={data.status.id} />
             <Subtitle>Mission</Subtitle>
             <DescWrapper>
-              {data.missions.map((mission) => (
-                <View key={mission.id}>
-                  <Label text={mission.typeName} />
-                  <View style={{ marginTop: 10 }}>
-                    <DescText>{mission.description}</DescText>
-                  </View>
+              <View>
+                <Label text={missionType} />
+                <View style={{ marginTop: 10 }}>
+                  <DescText>{missionDescription}</DescText>
                 </View>
-              ))}
-              {data.lsp.name && (
+              </View>
+              {data.launch_service_provider.name && (
                 <Row>
                   <Icon name="Briefcase" color={colors.accent} size={20} />
-                  <PinLabel numberOfLines={2}>{data.lsp.name}</PinLabel>
+                  <PinLabel numberOfLines={2}>{data.launch_service_provider.name}</PinLabel>
                 </Row>
               )}
               {data.net && (
                 <Row>
                   <Icon name="Clock" color={colors.accent} size={20} />
-                  <PinLabel numberOfLines={2}>{data.net}</PinLabel>
+                  <PinLabel numberOfLines={2}>{new Date(data.net).toLocaleString()}</PinLabel>
                 </Row>
               )}
-              {data.location.name && (
+              {data.pad.name && (
                 <Row>
                   <Icon name="Pin" color={colors.accent} size={20} />
-                  <PinLabel numberOfLines={2}>{data.location.name}</PinLabel>
+                  <PinLabel numberOfLines={2}>{data.pad.location.name}</PinLabel>
                 </Row>
               )}
             </DescWrapper>

--- a/src/screens/Search.tsx
+++ b/src/screens/Search.tsx
@@ -141,10 +141,10 @@ const SearchScreen = observer(({ navigation }) => {
         )}
         <TouchableOpacity
           onPress={() =>
-            openLink("https://launchlibrary.net/", appStateStore.browser)
+            openLink("https://thespacedevs.com/", appStateStore.browser)
           }
         >
-          <Footer>Data provided by the Launch Library</Footer>
+          <Footer>Data provided by Launch Library 2.0</Footer>
         </TouchableOpacity>
       </ScrollWrapper>
     </ContentWrapper>

--- a/src/stores/Launches.ts
+++ b/src/stores/Launches.ts
@@ -26,10 +26,10 @@ class Launches {
 
   loadNextLaunches = (numberOfLaunches = 10) => {
     this.state = STATES.LOADING;
-    fetch(`${API_URL}launch/next/${numberOfLaunches}`)
+    fetch(`${API_URL}launch/upcoming?limit=${numberOfLaunches}&mode=detailed`)
       .then((data) => data.json())
       .then((data) => {
-        this.launches = data.launches;
+        this.launches = data.results;
         this.state = STATES.SUCCESS;
       })
       .catch((err) => {
@@ -44,11 +44,11 @@ class Launches {
       .logEvent("LOAD_MORE_LAUNCHES", { value: numberOfLaunches });
     this.state = STATES.LOADING;
     fetch(
-      `${API_URL}launch/next/${numberOfLaunches}?offset=${this.launches.length}`
+      `${API_URL}launch/upcoming?limit=${numberOfLaunches}&offset=${this.launches.length}&mode=detailed`
     )
       .then((data) => data.json())
       .then((data) => {
-        this.launches = this.launches.concat(data.launches);
+        this.launches = this.launches.concat(data.results);
         this.state = STATES.SUCCESS;
       })
       .catch((err) => {

--- a/src/stores/Launches.ts
+++ b/src/stores/Launches.ts
@@ -104,9 +104,9 @@ class Launches {
             if (plannedNotifications.length > 0) {
               PushNotificationIOS.cancelAllLocalNotifications();
             }
-            if (data.wsstamp){
+            if (data.net){
               const fireDate = new Date(
-                (data.wsstamp - this.notifications.delay * 60) * 1000
+                (data.net - this.notifications.delay * 60) * 1000
               );
               PushNotificationIOS.scheduleLocalNotification({
                 fireDate: fireDate.toISOString(),
@@ -121,7 +121,7 @@ class Launches {
       if (this.notifications.enabled) {
         PushNotification.cancelAllLocalNotifications();
         PushNotification.localNotificationSchedule({
-          date: new Date(data.isostart),
+          date: new Date(data.net).toISOString(),
           message: `🚀 ${data.name} will launch in ${this.notifications.delay} minutes!`,
         });
       }

--- a/src/stores/Search.ts
+++ b/src/stores/Search.ts
@@ -42,11 +42,11 @@ export class Search {
 
   searchLaunches = (str) => {
     this.state = STATES.LOADING;
-    fetch(`${API_URL}launch/${str}`)
+    fetch(`${API_URL}launch?search=${str}`)
       .then((data) => data.json())
       .then((data) => {
-        this.results = data.launches || [];
-        this.totalResults = data.total;
+        this.results = data.results || [];
+        this.totalResults = data.count;
         this.state = STATES.SUCCESS;
         this.addHistoryItem(str);
       })


### PR DESCRIPTION
Since [Launch Library 1 is deprecated and will stop working](https://launchlibrary.net/) in the future, I took the liberty to update the app to use Launch Library 2, from [The Space Devs](https://thespacedevs.com/). I'm a partner developer within this group (Spaceflight News API; thanks for using it!). I have your app installed for quite some time now, and I really like the clean design.

What I did was simply rename some of the properties that have a different name in LL2. Since LL2 doesn't have things like netstamps, I've also done quite a few Date-parsings to get the NET to seconds. For most (if not all) time values, I've used the NET time. Some other things that are good to know:

- Descriptions are not always available. This is now checked when entering the "Details" screen. Check the upcoming Gaofen launch for an example;
- There are no longer mission wiki's in the response. I've changed this to LSP wiki pages;
- The "To be Determined" section might be obsolete now;
- I have not tested notifications;
- One of the tests is failing (the ResultCard one). I'm not sure why, so I've skipped it for now but you might wanna take a look at that :)

It's good to keep in mind that LL2 is free to use for 300 calls per day, per IP.

Please, let me know if you have any questions!